### PR TITLE
Refactor imports to use path aliases

### DIFF
--- a/src/app/components/add-call/add-call.component.ts
+++ b/src/app/components/add-call/add-call.component.ts
@@ -6,14 +6,14 @@ import {
   Validators,
 } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
-import { CallService } from '../../services/call.service';
-import { SubscriberService } from '../../services/subscriber.service';
-import { CityService } from '../../services/city.service';
-import { INewCall } from '../../interfaces/call';
-import { ISubscriber } from '../../interfaces/subscriber';
-import { ICity } from '../../interfaces/city';
-import { SnackbarService } from '../../services/snackbar.service';
-import { PhoneNumberFormatPipe } from '../../pipes/phone-number-format.pipe';
+import { CallService } from '@services/call.service';
+import { SubscriberService } from '@services/subscriber.service';
+import { CityService } from '@services/city.service';
+import { INewCall } from '@interfaces/call';
+import { ISubscriber } from '@interfaces/subscriber';
+import { ICity } from '@interfaces/city';
+import { SnackbarService } from '@services/snackbar.service';
+import { PhoneNumberFormatPipe } from '@pipes/phone-number-format.pipe';
 import { MatIconModule } from '@angular/material/icon';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatInputModule } from '@angular/material/input';
@@ -113,8 +113,10 @@ export class AddCallComponent {
         if (typeof value === 'string') {
           this.filteredSubscribers.set(
             this.subscribers().filter((subscriber) =>
-              subscriber.phoneNumber.toLowerCase().includes(value.toLowerCase())
-            )
+              subscriber.phoneNumber
+                .toLowerCase()
+                .includes(value.toLowerCase()),
+            ),
           );
         }
       });
@@ -126,8 +128,8 @@ export class AddCallComponent {
         if (typeof value === 'string') {
           this.filteredCities.set(
             this.cities().filter((city) =>
-              city.name.toLowerCase().includes(value.toLowerCase())
-            )
+              city.name.toLowerCase().includes(value.toLowerCase()),
+            ),
           );
         }
       });
@@ -184,7 +186,7 @@ export class AddCallComponent {
     if (startDateObj > endDateObj) {
       this.snackbarService.showMessage(
         'Start date must be earlier than end date!',
-        'error'
+        'error',
       );
       throw new Error('Start date must be earlier than end date!');
     }
@@ -197,10 +199,10 @@ export class AddCallComponent {
       if (startTimeInSeconds >= endTimeInSeconds) {
         this.snackbarService.showMessage(
           'Start time must be earlier than end time on the same date!',
-          'error'
+          'error',
         );
         throw new Error(
-          'Start time must be earlier than end time on the same date!'
+          'Start time must be earlier than end time on the same date!',
         );
       }
     }
@@ -208,13 +210,13 @@ export class AddCallComponent {
     const startDateTime = new Date(
       `${startDate}T${[startHour, startMinute, startSecond]
         .map((n) => String(n).padStart(2, '0'))
-        .join(':')}`
+        .join(':')}`,
     );
 
     const endDateTime = new Date(
       `${endDate}T${[endHour, endMinute, endSecond]
         .map((n) => String(n).padStart(2, '0'))
-        .join(':')}`
+        .join(':')}`,
     );
 
     return (endDateTime.getTime() - startDateTime.getTime()) / 1000;
@@ -246,14 +248,14 @@ export class AddCallComponent {
         this.dialogRef.close(result);
         this.snackbarService.showMessage(
           'Call created successfully!',
-          'success'
+          'success',
         );
       },
       error: (err) => {
         console.error('Error creating call:', err);
         this.snackbarService.showMessage(
           'Failed to create call. Please try again.',
-          'error'
+          'error',
         );
       },
     });

--- a/src/app/components/add-city/add-city.component.ts
+++ b/src/app/components/add-city/add-city.component.ts
@@ -1,5 +1,5 @@
 import { Component, DestroyRef, inject } from '@angular/core';
-import { CityService } from '../../services/city.service';
+import { CityService } from '@services/city.service';
 import {
   FormArray,
   FormBuilder,
@@ -8,8 +8,8 @@ import {
   Validators,
 } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
-import { SnackbarService } from '../../services/snackbar.service';
-import { INewCity } from '../../interfaces/city';
+import { SnackbarService } from '@services/snackbar.service';
+import { INewCity } from '@interfaces/city';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 
@@ -39,7 +39,7 @@ export class AddCityComponent {
   }
 
   createDiscountGroup(
-    discount: { duration?: number; discountRate?: number } = {}
+    discount: { duration?: number; discountRate?: number } = {},
   ) {
     return this.fb.group({
       duration: [

--- a/src/app/components/add-subscriber/add-subscriber.component.ts
+++ b/src/app/components/add-subscriber/add-subscriber.component.ts
@@ -6,10 +6,10 @@ import {
   Validators,
 } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
-import { INewSubscriber } from '../../interfaces/subscriber';
-import { SubscriberService } from '../../services/subscriber.service';
+import { INewSubscriber } from '@interfaces/subscriber';
+import { SubscriberService } from '@services/subscriber.service';
 import { MatIconModule } from '@angular/material/icon';
-import { SnackbarService } from '../../services/snackbar.service';
+import { SnackbarService } from '@services/snackbar.service';
 
 @Component({
   selector: 'app-add-subscriber',
@@ -49,7 +49,7 @@ export class AddSubscriberComponent {
           this.dialogRef.close(newSubscriber);
           this.snackbarService.showMessage(
             'New subscriber added successfully!',
-            'success'
+            'success',
           );
         },
         error: () => {},

--- a/src/app/components/city-card/city-card.component.ts
+++ b/src/app/components/city-card/city-card.component.ts
@@ -1,11 +1,11 @@
 import { Component, DestroyRef, inject, input, output } from '@angular/core';
-import { ICity } from '../../interfaces/city';
+import { ICity } from '@interfaces/city';
 import { MatIconModule } from '@angular/material/icon';
-import { CityService } from '../../services/city.service';
-import { SnackbarService } from '../../services/snackbar.service';
+import { CityService } from '@services/city.service';
+import { SnackbarService } from '@services/snackbar.service';
 import { MatDialog } from '@angular/material/dialog';
-import { EditCityComponent } from '../edit-city/edit-city.component';
-import { ConfirmationDialogComponent } from '../confirmation-dialog/confirmation-dialog.component';
+import { EditCityComponent } from '@components/edit-city/edit-city.component';
+import { ConfirmationDialogComponent } from '@components/confirmation-dialog/confirmation-dialog.component';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
@@ -63,14 +63,14 @@ export class CityCardComponent {
               next: () => {
                 this.snackbarService.showMessage(
                   'City deleted successfully',
-                  'success'
+                  'success',
                 );
                 this.cityDeleted.emit(id);
               },
               error: (err: Error) => {
                 this.snackbarService.showMessage(
                   `Error: ${err.message}`,
-                  'error'
+                  'error',
                 );
               },
             });

--- a/src/app/components/edit-city/edit-city.component.ts
+++ b/src/app/components/edit-city/edit-city.component.ts
@@ -8,10 +8,10 @@ import {
 } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { ICity, INewCity } from '../../interfaces/city';
-import { CityService } from '../../services/city.service';
+import { ICity, INewCity } from '@interfaces/city';
+import { CityService } from '@services/city.service';
 import { MatIconModule } from '@angular/material/icon';
-import { SnackbarService } from '../../services/snackbar.service';
+import { SnackbarService } from '@services/snackbar.service';
 
 @Component({
   selector: 'app-edit-city',
@@ -37,8 +37,8 @@ export class EditCityComponent {
         this.createDiscountGroup({
           ...discount,
           discountRate: discount.discountRate * 100,
-        })
-      )
+        }),
+      ),
     ),
   });
 
@@ -47,7 +47,7 @@ export class EditCityComponent {
   }
 
   createDiscountGroup(
-    discount: { duration?: number; discountRate?: number } = {}
+    discount: { duration?: number; discountRate?: number } = {},
   ) {
     return this.fb.group({
       duration: [discount.duration, [Validators.required, Validators.min(1)]],
@@ -84,7 +84,7 @@ export class EditCityComponent {
         next: (result) => {
           this.snackbarService.showMessage(
             'City updated successfully',
-            'success'
+            'success',
           );
           this.dialogRef.close(result);
         },

--- a/src/app/components/edit-subscriber/edit-subscriber.component.ts
+++ b/src/app/components/edit-subscriber/edit-subscriber.component.ts
@@ -6,10 +6,10 @@ import {
   Validators,
 } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { INewSubscriber, ISubscriber } from '../../interfaces/subscriber';
-import { SubscriberService } from '../../services/subscriber.service';
+import { INewSubscriber, ISubscriber } from '@interfaces/subscriber';
+import { SubscriberService } from '@services/subscriber.service';
 import { MatIconModule } from '@angular/material/icon';
-import { SnackbarService } from '../../services/snackbar.service';
+import { SnackbarService } from '@services/snackbar.service';
 
 @Component({
   selector: 'app-edit-subscriber',
@@ -55,7 +55,7 @@ export class EditSubscriberComponent {
         next: (updatedSubscriber) => {
           this.snackbarService.showMessage(
             'Subscriber updated successfully',
-            'success'
+            'success',
           );
           this.dialogRef.close(updatedSubscriber);
         },

--- a/src/app/components/subscriber-card/subscriber-card.component.ts
+++ b/src/app/components/subscriber-card/subscriber-card.component.ts
@@ -1,14 +1,14 @@
 import { Component, DestroyRef, inject, input, output } from '@angular/core';
-import { ISubscriberCard } from '../../interfaces/subscriber';
+import { ISubscriberCard } from '@interfaces/subscriber';
 import { RouterLink } from '@angular/router';
-import { PhoneNumberFormatPipe } from '../../pipes/phone-number-format.pipe';
+import { PhoneNumberFormatPipe } from '@pipes/phone-number-format.pipe';
 import { MatIconModule } from '@angular/material/icon';
-import { SubscriberService } from '../../services/subscriber.service';
-import { SnackbarService } from '../../services/snackbar.service';
+import { SubscriberService } from '@services/subscriber.service';
+import { SnackbarService } from '@services/snackbar.service';
 import { MatDialog } from '@angular/material/dialog';
-import { EditSubscriberComponent } from '../edit-subscriber/edit-subscriber.component';
+import { EditSubscriberComponent } from '@components/edit-subscriber/edit-subscriber.component';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ConfirmationDialogComponent } from '../confirmation-dialog/confirmation-dialog.component';
+import { ConfirmationDialogComponent } from '@components/confirmation-dialog/confirmation-dialog.component';
 
 @Component({
   selector: 'app-subscriber-card',
@@ -65,7 +65,7 @@ export class SubscriberCardComponent {
               next: () => {
                 this.snackbarService.showMessage(
                   'Subscriber deleted successfully',
-                  'success'
+                  'success',
                 );
                 this.subscriberDeleted.emit(id);
               },
@@ -74,7 +74,7 @@ export class SubscriberCardComponent {
                   err?.message || 'An unknown error occurred';
                 this.snackbarService.showMessage(
                   `Error: ${errorMessage}`,
-                  'error'
+                  'error',
                 );
               },
             });

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -1,5 +1,5 @@
 import { inject } from '@angular/core';
-import { AdminService } from '../services/admin.service';
+import { AdminService } from '@services/admin.service';
 import { Router } from '@angular/router';
 
 export const authGuard = () => {

--- a/src/app/guards/authRedirect.guard.ts
+++ b/src/app/guards/authRedirect.guard.ts
@@ -1,5 +1,5 @@
 import { inject } from '@angular/core';
-import { AdminService } from '../services/admin.service';
+import { AdminService } from '@services/admin.service';
 import { Router } from '@angular/router';
 
 export const authRedirectGuard = () => {

--- a/src/app/interceptors/auth.interceptor.ts
+++ b/src/app/interceptors/auth.interceptor.ts
@@ -1,6 +1,6 @@
 import { HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
-import { AdminService } from '../services/admin.service';
+import { AdminService } from '@services/admin.service';
 
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const token = inject(AdminService).token;

--- a/src/app/interceptors/error.interceptor.ts
+++ b/src/app/interceptors/error.interceptor.ts
@@ -7,7 +7,7 @@ import {
   HttpErrorResponse,
 } from '@angular/common/http';
 import { Observable, catchError, throwError } from 'rxjs';
-import { SnackbarService } from '../services/snackbar.service';
+import { SnackbarService } from '@services/snackbar.service';
 
 @Injectable()
 export class errorInterceptor implements HttpInterceptor {
@@ -15,7 +15,7 @@ export class errorInterceptor implements HttpInterceptor {
 
   intercept(
     req: HttpRequest<any>,
-    next: HttpHandler
+    next: HttpHandler,
   ): Observable<HttpEvent<any>> {
     return next.handle(req).pipe(
       catchError((error: HttpErrorResponse) => {
@@ -23,7 +23,7 @@ export class errorInterceptor implements HttpInterceptor {
           error.error?.message || 'An unexpected error occurred';
         this.snackbarService.showMessage(errorMessage, 'error');
         return throwError(() => error);
-      })
+      }),
     );
   }
 }

--- a/src/app/layouts/header/header.component.ts
+++ b/src/app/layouts/header/header.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { AdminService } from '../../services/admin.service';
+import { AdminService } from '@services/admin.service';
 import { RouterLink } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
 

--- a/src/app/layouts/layout/layout.component.ts
+++ b/src/app/layouts/layout/layout.component.ts
@@ -1,8 +1,8 @@
 import { Component, signal } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { SidebarComponent } from '../sidebar/sidebar.component';
-import { HeaderComponent } from '../header/header.component';
-import { NavBottomComponent } from '../nav-bottom/nav-bottom.component';
+import { SidebarComponent } from '@layouts/sidebar/sidebar.component';
+import { HeaderComponent } from '@layouts/header/header.component';
+import { NavBottomComponent } from '@layouts/nav-bottom/nav-bottom.component';
 
 @Component({
   selector: 'app-layout',

--- a/src/app/layouts/sidebar/sidebar.component.ts
+++ b/src/app/layouts/sidebar/sidebar.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, signal } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { AdminService } from '../../services/admin.service';
+import { AdminService } from '@services/admin.service';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 
 @Component({

--- a/src/app/pages/calls/calls.component.ts
+++ b/src/app/pages/calls/calls.component.ts
@@ -1,12 +1,12 @@
 import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
-import { CallService } from '../../services/call.service';
-import { ICall } from '../../interfaces/call';
+import { CallService } from '@services/call.service';
+import { ICall } from '@interfaces/call';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { PhoneNumberFormatPipe } from '../../pipes/phone-number-format.pipe';
+import { PhoneNumberFormatPipe } from '@pipes/phone-number-format.pipe';
 import { CurrencyPipe, DatePipe } from '@angular/common';
-import { DurationFormatPipe } from '../../pipes/duration-format.pipe';
+import { DurationFormatPipe } from '@pipes/duration-format.pipe';
 import { MatDialog } from '@angular/material/dialog';
-import { AddCallComponent } from '../../components/add-call/add-call.component';
+import { AddCallComponent } from '@components/add-call/add-call.component';
 import { MatIconModule } from '@angular/material/icon';
 
 @Component({
@@ -42,18 +42,18 @@ export class CallsComponent {
         s.subscriber.toLowerCase().includes(term) ||
         s.city.toLowerCase().includes(term) ||
         s.duration.toString().includes(term) ||
-        s.timeOfDay.toLowerCase().includes(term)
+        s.timeOfDay.toLowerCase().includes(term),
     );
 
     switch (option) {
       case 'newest':
         sortedCalls.sort(
-          (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+          (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
         );
         break;
       case 'oldest':
         sortedCalls.sort(
-          (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+          (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
         );
         break;
       case 'longest':

--- a/src/app/pages/cities/cities.component.ts
+++ b/src/app/pages/cities/cities.component.ts
@@ -1,10 +1,10 @@
 import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
-import { CityService } from '../../services/city.service';
-import { ICity } from '../../interfaces/city';
-import { CityCardComponent } from '../../components/city-card/city-card.component';
+import { CityService } from '@services/city.service';
+import { ICity } from '@interfaces/city';
+import { CityCardComponent } from '@components/city-card/city-card.component';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatDialog } from '@angular/material/dialog';
-import { AddCityComponent } from '../../components/add-city/add-city.component';
+import { AddCityComponent } from '@components/add-city/add-city.component';
 
 @Component({
   selector: 'app-cities',
@@ -27,7 +27,7 @@ export class CitiesComponent {
     return this.cities().filter(
       (s) =>
         s._id.toLowerCase().includes(term) ||
-        s.name.toLowerCase().includes(term)
+        s.name.toLowerCase().includes(term),
     );
   });
 
@@ -79,8 +79,8 @@ export class CitiesComponent {
   onCityUpdated(updatedCity: ICity) {
     this.cities.set(
       this.cities().map((s) =>
-        s._id === updatedCity._id ? { ...s, ...updatedCity } : s
-      )
+        s._id === updatedCity._id ? { ...s, ...updatedCity } : s,
+      ),
     );
   }
 }

--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -5,11 +5,11 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
-import { AdminService } from '../../services/admin.service';
+import { AdminService } from '@services/admin.service';
 import { Router } from '@angular/router';
-import { SnackbarService } from '../../services/snackbar.service';
+import { SnackbarService } from '@services/snackbar.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ITokenResponse } from '../../interfaces/admin';
+import { ITokenResponse } from '@interfaces/admin';
 
 @Component({
   selector: 'app-login',
@@ -53,7 +53,7 @@ export class LoginComponent {
           console.error('Request error:', err.message);
           this.snackbarService.showMessage(
             'Incorrect email or password.',
-            'error'
+            'error',
           );
         },
       });

--- a/src/app/pages/subscriber-details/subscriber-details.component.ts
+++ b/src/app/pages/subscriber-details/subscriber-details.component.ts
@@ -1,12 +1,12 @@
 import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { SubscriberService } from '../../services/subscriber.service';
-import { ISubscriberDetails } from '../../interfaces/subscriber';
-import { SnackbarService } from '../../services/snackbar.service';
+import { SubscriberService } from '@services/subscriber.service';
+import { ISubscriberDetails } from '@interfaces/subscriber';
+import { SnackbarService } from '@services/snackbar.service';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { PhoneNumberFormatPipe } from '../../pipes/phone-number-format.pipe';
+import { PhoneNumberFormatPipe } from '@pipes/phone-number-format.pipe';
 import { CurrencyPipe, DatePipe } from '@angular/common';
-import { DurationFormatPipe } from '../../pipes/duration-format.pipe';
+import { DurationFormatPipe } from '@pipes/duration-format.pipe';
 import { MatIconModule } from '@angular/material/icon';
 
 @Component({
@@ -50,7 +50,7 @@ export class SubscriberDetailsComponent {
             console.error('Error loading subscriber details:', err.message);
             this.snackbarService.showMessage(
               'Error loading subscriber details',
-              'error'
+              'error',
             );
             this.router.navigate(['/subscribers']);
           },

--- a/src/app/pages/subscribers/subscribers.component.ts
+++ b/src/app/pages/subscribers/subscribers.component.ts
@@ -1,10 +1,10 @@
 import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
-import { SubscriberService } from '../../services/subscriber.service';
-import { ISubscriberCard } from '../../interfaces/subscriber';
-import { SubscriberCardComponent } from '../../components/subscriber-card/subscriber-card.component';
+import { SubscriberService } from '@services/subscriber.service';
+import { ISubscriberCard } from '@interfaces/subscriber';
+import { SubscriberCardComponent } from '@components/subscriber-card/subscriber-card.component';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatDialog } from '@angular/material/dialog';
-import { AddSubscriberComponent } from '../../components/add-subscriber/add-subscriber.component';
+import { AddSubscriberComponent } from '@components/add-subscriber/add-subscriber.component';
 
 @Component({
   selector: 'app-subscribers',
@@ -27,7 +27,7 @@ export class SubscribersComponent {
     return this.subscribers().filter(
       (s) =>
         s._id.toLowerCase().includes(term) ||
-        s.phoneNumber.toLowerCase().includes(term)
+        s.phoneNumber.toLowerCase().includes(term),
     );
   });
 
@@ -78,8 +78,8 @@ export class SubscribersComponent {
   onSubscriberUpdated(updatedSubscriber: ISubscriberCard) {
     this.subscribers.set(
       this.subscribers().map((s) =>
-        s._id === updatedSubscriber._id ? { ...s, ...updatedSubscriber } : s
-      )
+        s._id === updatedSubscriber._id ? { ...s, ...updatedSubscriber } : s,
+      ),
     );
   }
 }

--- a/src/app/services/admin.service.ts
+++ b/src/app/services/admin.service.ts
@@ -1,10 +1,10 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { IAdminLogin, ITokenResponse } from '../interfaces/admin';
+import { IAdminLogin, ITokenResponse } from '@interfaces/admin';
 import { tap } from 'rxjs';
 import { CookieService } from 'ngx-cookie-service';
 import { Router } from '@angular/router';
-import { environment } from '../../environments/environment';
+import { environment } from '@env/environment';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/services/call.service.ts
+++ b/src/app/services/call.service.ts
@@ -1,8 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { ICall, INewCall } from '../interfaces/call';
+import { ICall, INewCall } from '@interfaces/call';
 import { catchError, Observable, throwError } from 'rxjs';
-import { environment } from '../../environments/environment';
+import { environment } from '@env/environment';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/services/city.service.ts
+++ b/src/app/services/city.service.ts
@@ -1,8 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { ICity, INewCity } from '../interfaces/city';
+import { ICity, INewCity } from '@interfaces/city';
 import { catchError, Observable, throwError } from 'rxjs';
-import { environment } from '../../environments/environment';
+import { environment } from '@env/environment';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/services/snackbar.service.ts
+++ b/src/app/services/snackbar.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { SnackbarComponent } from '../components/snackbar/snackbar.component';
+import { SnackbarComponent } from '@components/snackbar/snackbar.component';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/services/subscriber.service.ts
+++ b/src/app/services/subscriber.service.ts
@@ -5,9 +5,9 @@ import {
   ISubscriber,
   ISubscriberCard,
   ISubscriberDetails,
-} from '../interfaces/subscriber';
+} from '@interfaces/subscriber';
 import { catchError, Observable, throwError } from 'rxjs';
-import { environment } from '../../environments/environment';
+import { environment } from '@env/environment';
 
 @Injectable({
   providedIn: 'root',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,18 @@
   "compilerOptions": {
     "outDir": "./dist/out-tsc",
     "strict": true,
+    "baseUrl": "./",
+    "paths": {
+      "@components/*": ["src/app/components/*"],
+      "@guards/*": ["src/app/guards/*"],
+      "@interceptors/*": ["src/app/interceptors/*"],
+      "@interfaces/*": ["src/app/interfaces/*"],
+      "@layouts/*": ["src/app/layouts/*"],
+      "@pages/*": ["src/app/pages/*"],
+      "@pipes/*": ["src/app/pipes/*"],
+      "@services/*": ["src/app/services/*"],
+      "@env/*": ["src/environments/*"]
+    },
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
### Summary

This PR introduces path aliases and refactors existing relative imports to improve readability and maintainability.

### Changes

* Added path aliases configuration in `tsconfig.json`
* Updated build configuration to support aliases
* Replaced relative imports with aliases across the codebase
* Verified build and tests pass successfully

### Example

Before:

```ts
import Button from "../../../components/Button";
```

After:

```ts
import Button from "@components/Button";
```

### Benefits

* Improved code readability
* Easier refactoring
* Reduced risk of broken imports when moving files