### PR TITLE
Add login loading state and enhance snackbar component

### DIFF
--- a/src/app/components/snackbar/snackbar.component.html
+++ b/src/app/components/snackbar/snackbar.component.html
@@ -1,4 +1,4 @@
-<mat-icon [ngClass]="data.type === 'success' ? 'success' : 'error'">
-  {{ data.type === "success" ? "check_circle" : "cancel" }}
+<mat-icon [ngClass]="data.type">
+  {{ iconName }}
 </mat-icon>
 <span class="snackbar-message">{{ data.message }}</span>

--- a/src/app/components/snackbar/snackbar.component.scss
+++ b/src/app/components/snackbar/snackbar.component.scss
@@ -9,15 +9,8 @@
   background: var(--charcoal);
 }
 
-.snack-bar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 16px;
-  padding: 12px 16px;
-  border-radius: 8px;
-  color: white;
-  font-weight: 500;
+.snackbar-message {
+  flex: 1;
 }
 
 .success {
@@ -26,4 +19,8 @@
 
 .error {
   color: var(--blaze);
+}
+
+.info {
+  color: var(--amber);
 }

--- a/src/app/components/snackbar/snackbar.component.ts
+++ b/src/app/components/snackbar/snackbar.component.ts
@@ -13,6 +13,19 @@ import { MAT_SNACK_BAR_DATA } from '@angular/material/snack-bar';
 export class SnackbarComponent {
   constructor(
     @Inject(MAT_SNACK_BAR_DATA)
-    public data: { message: string; type: 'success' | 'error' }
+    public data: { message: string; type: 'success' | 'error' | 'info' },
   ) {}
+
+  get iconName(): string {
+    switch (this.data.type) {
+      case 'success':
+        return 'check_circle';
+      case 'error':
+        return 'cancel';
+      case 'info':
+        return 'info';
+      default:
+        return 'info';
+    }
+  }
 }

--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -26,6 +26,7 @@ export class LoginComponent {
   private destroyRef = inject(DestroyRef);
 
   public isLoading = false;
+  private delayTimer?: ReturnType<typeof setTimeout>;
 
   form = new FormGroup({
     email: new FormControl(null, [Validators.required, Validators.email]),
@@ -43,6 +44,13 @@ export class LoginComponent {
 
     this.isLoading = true;
 
+    this.delayTimer = setTimeout(() => {
+      this.snackbarService.showMessage(
+        'The server is waking up, this may take up to a minute. Please wait a little longer...',
+        'info',
+      );
+    }, 5000);
+
     const subscription = this.adminService
       .login({
         email: this.form.value.email!,
@@ -52,6 +60,8 @@ export class LoginComponent {
         takeUntilDestroyed(this.destroyRef),
         finalize(() => {
           this.isLoading = false;
+
+          clearTimeout(this.delayTimer);
         }),
       )
       .subscribe({

--- a/src/app/services/snackbar.service.ts
+++ b/src/app/services/snackbar.service.ts
@@ -8,7 +8,10 @@ import { SnackbarComponent } from '@components/snackbar/snackbar.component';
 export class SnackbarService {
   private _snackBar = inject(MatSnackBar);
 
-  showMessage(message: string, type: 'success' | 'error' = 'success') {
+  public showMessage(
+    message: string,
+    type: 'success' | 'error' | 'info' = 'success',
+  ): void {
     this._snackBar.openFromComponent(SnackbarComponent, {
       data: { message, type },
       duration: 5000,

--- a/src/app/styles/_vars.scss
+++ b/src/app/styles/_vars.scss
@@ -13,6 +13,7 @@
   --lavender: #5c62ec;
   --blaze: #e64a19;
   --emerald: #4caf50;
+  --amber: #ffab00;
 
   /* hover effects */
   --frosted-glass: rgba(255, 255, 255, 0.05);


### PR DESCRIPTION
### Summary
Show an informational snackbar if a request takes longer than 5 seconds.

### Changes
* Added `setTimeout` on request start
* Cleared timeout in `finalize`
* Added `'info'` type to `SnackbarService`
* Made snackbar duration configurable
* Updated snackbar component and styles


### Why:
To improve user experience on the free Render tier, as the backend needs time to start after a period of inactivity.