### PR TITLE
Add Bearer prefix to Authorization header (#34)

### DIFF
--- a/src/app/interceptors/auth.interceptor.spec.ts
+++ b/src/app/interceptors/auth.interceptor.spec.ts
@@ -41,7 +41,7 @@ describe('AuthInterceptor', () => {
   });
 
   it('should add an Authorization header when a token is present in AdminService (TC-20)', () => {
-    const fakeToken = 'Bearer valid-jwt-token-123';
+    const fakeToken = 'valid-jwt-token-123';
     adminServiceMock.token = fakeToken;
 
     httpClient.get(testUrl).subscribe();
@@ -50,7 +50,9 @@ describe('AuthInterceptor', () => {
 
     expect(req.request.headers.has('Authorization')).toBeTrue();
 
-    expect(req.request.headers.get('Authorization')).toBe(fakeToken);
+    expect(req.request.headers.get('Authorization')).toBe(
+      `Bearer ${fakeToken}`,
+    );
 
     req.flush({});
   });

--- a/src/app/interceptors/auth.interceptor.ts
+++ b/src/app/interceptors/auth.interceptor.ts
@@ -8,7 +8,7 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
   if (token) {
     const clonedRequest = req.clone({
       setHeaders: {
-        Authorization: token,
+        Authorization: `Bearer ${token}`,
       },
     });
     return next(clonedRequest);


### PR DESCRIPTION
## Issue
The Authorization header was sent as a raw token without the “Bearer” prefix,
which violates RFC 6750. The current backend handles both formats,
but third-party services will reject such a request.

## Solution
Authorization: token  →  Authorization: `Bearer ${token}`

## Testing
DevTools → Network → any authenticated request → Request Headers:
- Before: Authorization: eyJhbGci...
- After: Authorization: Bearer eyJhbGci...